### PR TITLE
fix: add Provides to chromium

### DIFF
--- a/chromium-fixup.sh
+++ b/chromium-fixup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+fakeroot bash -c '
+    DEB="chromium_128.0.6613.84-1.deb12u1_arm64.deb"
+    rm -rf tmp
+    mkdir tmp
+    dpkg-deb -R $DEB tmp
+    sed -Ei "/Provides/ s/$/, chromium-cix/" tmp/DEBIAN/control
+    dpkg-deb -b tmp ${DEB/.deb}-fixed.deb
+'


### PR DESCRIPTION
`chromium-common`的版本本身就设置好了，因此不用担心拉到上游的`chromium-common`。
```
...
chromium-common (= 128.0.6613.84-1~deb12u1)
Recommends: chromium-sandbox
...
```